### PR TITLE
fix(ds/monotonous-queue.md): 添加别名并替换题目链接

### DIFF
--- a/docs/ds/monotonous-queue.md
+++ b/docs/ds/monotonous-queue.md
@@ -1,11 +1,11 @@
-author: Link-cute, Xeonacid, ouuan, Alphnia
+author: Link-cute, Xeonacid, ouuan, Alphnia, Lyccrius
 
 ## 引入
 
-在学习单调队列前，让我们先来看一道例题。
+在学习单调队列（有序队列）前，让我们先来看一道例题。
 
 ???+note "例题"
-    [Sliding Window](http://poj.org/problem?id=2823)
+    [Luogu P1886 滑动窗口 /【模板】单调队列](https://www.luogu.com.cn/problem/P1886)
     
     本题大意是给出一个长度为 $n$ 的数组，编程输出每 $k$ 个连续的数中的最大值和最小值。
 


### PR DESCRIPTION
根据[NOI大纲](https://www.noi.cn/xw/2021-04-02/724387.shtml)添加别名“有序队列”，以便混淆概念的读者索引界面;  

将题目“滑动窗口”链接由 POJ 替换为 Luogu.